### PR TITLE
correct get() result for buffer ending between CR and LF

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,14 +12,24 @@ function get(fileLocation, _, callback) {
 
     var reader = fs.createReadStream(fileLocation);
     var ran = false;
+    var tentativePreviousString;
+    var tentativeEndingType;
     reader.on('data', function(buffer) {
       if (!ran) {
-        var matched = buffer.toString().match(/\r\n|\r|\n/);
+        var str = (tentativePreviousString || '') + buffer.toString();
+        var matched = str.match(/\r\n|\r|\n/);
         var returned = {
           '\r': 'CR',
           '\n': 'LF',
           '\r\n': 'CRLF',
         }[matched];
+        if (matched && returned === 'CR') { // handle case where current buffer ends between CR and LF of CRLF
+          if (!str.match(/\r./)) { // make sure CR is followed by something other than end of string
+            tentativePreviousString = str;
+            tentativeEndingType = 'CR';
+            return;
+          }
+        }
         if (matched) {
           ran = true;
           reader.destroy();
@@ -30,7 +40,7 @@ function get(fileLocation, _, callback) {
     reader.on('end', function(buffer) {
       if (!ran) {
         ran = true;
-        callback(null, 'NA');
+        callback(null, tentativeEndingType || 'NA');
       }
     });
   });


### PR DESCRIPTION
If the read buffer ends between the CR and LF in a CRLF file, get() will incorrectly determine the line ending to be CR. If a buffer only has a CR at the end, we should combine it with the next buffer to see if it is truly a CR file or a CRLF file.